### PR TITLE
Turned single quotes into double quotes

### DIFF
--- a/lib/Dist/Zilla/Plugin/LicenseFromModule.pm
+++ b/lib/Dist/Zilla/Plugin/LicenseFromModule.pm
@@ -26,7 +26,7 @@ sub _file_from_filename {
     for my $file (@{$self->zilla->files}) {
         return $file if $file->name eq $filename;
     }
-    die 'no file module $filename in dist';
+    die "no file module $filename in dist";
 }
 
 use Software::LicenseUtils;


### PR DESCRIPTION
Single quotes were preventing proper printing of the filename in the output message of die().
